### PR TITLE
Done with v0 of `llvc`

### DIFF
--- a/llvc/README.md
+++ b/llvc/README.md
@@ -1,11 +1,11 @@
 # README
 
 
-## Build 
+## Build
 
-- `stack build` 
+- `stack build`
 
-## Run 
+## Run
 
 First, generate the .smt2 files, one per function defined in the `.ll` file
 
@@ -33,12 +33,172 @@ declare float @llvm.fabs.f32(float) #0
 ;@ ensures  (fp.eq %ret (fp.abs %arg0))
 ```
 
-### Definitions 
+### Definitions
 
 ```ll
 define weak float @ctfp_restrict_add_f32v1(float %a, float %b) #1 {
-;@ requires true 
+;@ requires true
 ;@ ensures  true
 ...
 }
+```
+
+## Running `llvc`
+
+You can check **all** the functions in a file 
+
+```
+$ stack exec -- llvc test/ll/restrict.cse.ll
+```
+
+or check a **subset** of the functions 
+
+```
+$ stack exec -- llvc test/ll/restrict.cse.ll @ctfp_restrict_add_f32v1
+```
+rjhala@borscht ~/r/C/llvc (CHECKPOINT)> stack exec -- llvc test/ll/restrict.cse.ll @ctfp_restrict_add_f32v1
+
+llvc: checking "test/ll/restrict.cse.ll"
+
+Goals: @ctfp_restrict_add_f32v1
+
+Yikes, errors found!
+
+test/ll/restrict.cse.ll:27:13-16: Failed ensures check!
+
+        27|    ret float %11
+                         ^^^^
+
+(model
+  (define-fun r2 () Bool
+    false)
+  (define-fun r7 () (_ BitVec 32)
+    #x7f800000)
+  (define-fun r8 () (_ BitVec 32)
+    #x7f800000)
+  (define-fun rb () Float32
+    (_ -oo 8 24))
+  (define-fun r9 () Float32
+    (fp #b0 #x9d #b11111110000000000000000))
+  (define-fun r3 () (_ BitVec 32)
+    #x00000000)
+  (define-fun r11 () Float32
+    (_ -oo 8 24))
+  (define-fun ra () Float32
+    (_ +oo 8 24))
+  (define-fun r4 () Float32
+    (_ +zero 8 24))
+  (define-fun r5 () (_ BitVec 32)
+    #xffffffff)
+  (define-fun r10 () Float32
+    (fp #b0 #x9d #b00111011111111000000000))
+  (define-fun r1 () Float32
+    (_ +oo 8 24))
+  (define-fun r6 () Float32
+    (fp #b1 #x7f #b00000000000000000000000))
+  (define-fun fp.to_ieee_bv ((x!0 Float32)) (_ BitVec 32)
+    (ite (= x!0 (_ +oo 8 24)) #x7f800004
+    (ite (= x!0 (fp #b0 #x9d #b11111110000000000000000)) #x7f804000
+      #x7f800004)))
+)
+
+
+## Errors and Models 
+
+If there are **failed** verification conditions, `llvc` will print out 
+
+- the relevant _line_
+- the SMT _model_
+
+corresponding to the values that yield the failed check.
+
+```bash
+
+llvc: checking "test/ll/restrict.cse.ll"
+
+Goals: @ctfp_restrict_add_f32v1_1, @ctfp_restrict_add_f32v1_2, @ctfp_restrict_add_f32v1
+
+Yikes, errors found!
+
+test/ll/restrict.cse.ll:27:13-16: Failed ensures check!
+
+        27|    ret float %11
+                         ^^^^
+
+(model
+  (define-fun r2 () Bool
+    false)
+  (define-fun r7 () (_ BitVec 32)
+    #x7f800000)
+  (define-fun r8 () (_ BitVec 32)
+    #x7f800000)
+  (define-fun rb () Float32
+    (_ -oo 8 24))
+  (define-fun r9 () Float32
+    (fp #b0 #x9d #b11111110000000000000000))
+  (define-fun r3 () (_ BitVec 32)
+    #x00000000)
+  (define-fun r11 () Float32
+    (_ -oo 8 24))
+  (define-fun ra () Float32
+    (_ +oo 8 24))
+  (define-fun r4 () Float32
+    (_ +zero 8 24))
+  (define-fun r5 () (_ BitVec 32)
+    #xffffffff)
+  (define-fun r10 () Float32
+    (fp #b0 #x9d #b00111011111111000000000))
+  (define-fun r1 () Float32
+    (_ +oo 8 24))
+  (define-fun r6 () Float32
+    (fp #b1 #x7f #b00000000000000000000000))
+  (define-fun fp.to_ieee_bv ((x!0 Float32)) (_ BitVec 32)
+    (ite (= x!0 (_ +oo 8 24)) #x7f800004
+    (ite (= x!0 (fp #b0 #x9d #b11111110000000000000000)) #x7f804000
+      #x7f800004)))
+)
+
+test/ll/restrict.cse.ll:47:13-16: Failed ensures check!
+
+        47|    ret float %13
+                         ^^^^
+
+
+(model
+  (define-fun r8 () (_ BitVec 32)
+    #xbf800000)
+  (define-fun r12 () Float32
+    (_ +zero 8 24))
+  (define-fun r10 () (_ BitVec 32)
+    #x00000000)
+  (define-fun r6 () (_ BitVec 32)
+    #xffffffff)
+  (define-fun r2 () Bool
+    false)
+  (define-fun rb () Float32
+    (fp #b0 #x80 #b00000000000100000000000))
+  (define-fun r7 () Float32
+    (fp #b1 #x7f #b00000000000000000000000))
+  (define-fun r9 () (_ BitVec 32)
+    #x40000800)
+  (define-fun r3 () (_ BitVec 32)
+    #x00000000)
+  (define-fun r11 () Float32
+    (_ +zero 8 24))
+  (define-fun ra () Float32
+    (fp #b0 #x82 #b00000010001001100000000))
+  (define-fun r4 () Float32
+    (_ +zero 8 24))
+  (define-fun r5 () (_ BitVec 32)
+    #x00000000)
+  (define-fun r1 () Float32
+    (fp #b0 #x80 #b00000000000100000000000))
+  (define-fun r13 () Float32
+    (fp #b0 #x82 #b00000010001001100000000))
+  (define-fun fp.to_ieee_bv ((x!0 Float32)) (_ BitVec 32)
+    (ite (= x!0 (fp #b1 #x7f #b00000000000000000000000)) #x7f808000
+    (ite (= x!0 (fp #b0 #x80 #b00000000000100000000000)) #x7f801000
+    (ite (= x!0 (_ +zero 8 24)) #x7f820000
+      #x7f808000))))
+)
 ```

--- a/llvc/README.md
+++ b/llvc/README.md
@@ -56,52 +56,6 @@ or check a **subset** of the functions
 ```
 $ stack exec -- llvc test/ll/restrict.cse.ll @ctfp_restrict_add_f32v1
 ```
-rjhala@borscht ~/r/C/llvc (CHECKPOINT)> stack exec -- llvc test/ll/restrict.cse.ll @ctfp_restrict_add_f32v1
-
-llvc: checking "test/ll/restrict.cse.ll"
-
-Goals: @ctfp_restrict_add_f32v1
-
-Yikes, errors found!
-
-test/ll/restrict.cse.ll:27:13-16: Failed ensures check!
-
-        27|    ret float %11
-                         ^^^^
-
-(model
-  (define-fun r2 () Bool
-    false)
-  (define-fun r7 () (_ BitVec 32)
-    #x7f800000)
-  (define-fun r8 () (_ BitVec 32)
-    #x7f800000)
-  (define-fun rb () Float32
-    (_ -oo 8 24))
-  (define-fun r9 () Float32
-    (fp #b0 #x9d #b11111110000000000000000))
-  (define-fun r3 () (_ BitVec 32)
-    #x00000000)
-  (define-fun r11 () Float32
-    (_ -oo 8 24))
-  (define-fun ra () Float32
-    (_ +oo 8 24))
-  (define-fun r4 () Float32
-    (_ +zero 8 24))
-  (define-fun r5 () (_ BitVec 32)
-    #xffffffff)
-  (define-fun r10 () Float32
-    (fp #b0 #x9d #b00111011111111000000000))
-  (define-fun r1 () Float32
-    (_ +oo 8 24))
-  (define-fun r6 () Float32
-    (fp #b1 #x7f #b00000000000000000000000))
-  (define-fun fp.to_ieee_bv ((x!0 Float32)) (_ BitVec 32)
-    (ite (= x!0 (_ +oo 8 24)) #x7f800004
-    (ite (= x!0 (fp #b0 #x9d #b11111110000000000000000)) #x7f804000
-      #x7f800004)))
-)
-
 
 ## Errors and Models 
 
@@ -113,10 +67,11 @@ If there are **failed** verification conditions, `llvc` will print out
 corresponding to the values that yield the failed check.
 
 ```bash
+$ stack exec -- llvc test/ll/restrict.cse.ll
 
-llvc: checking "test/ll/restrict.cse.ll"
-
-Goals: @ctfp_restrict_add_f32v1_1, @ctfp_restrict_add_f32v1_2, @ctfp_restrict_add_f32v1
+llvc checking: @ctfp_restrict_add_f32v1_1
+llvc checking: @ctfp_restrict_add_f32v1_2
+llvc checking: @ctfp_restrict_add_f32v1
 
 Yikes, errors found!
 

--- a/llvc/app/Main.hs
+++ b/llvc/app/Main.hs
@@ -31,6 +31,12 @@ filterGoals All       xs = xs
 filterGoals (Some fs) xs = filter ((`elem` fs) . fst) xs 
 
 checkVC :: FilePath -> (Text, VC) -> IO () 
+checkVC f (fn, vc) = 
+  runQuery f smtF vc
+  where 
+    smtF = f <.> tail fn <.> "smt2"
+{- 
+checkVC :: FilePath -> (Text, VC) -> IO () 
 checkVC f (fn, vc) = do 
   let smtF = f <.> tail fn <.> "smt2"
   -- let logF = f <.> "log"
@@ -41,6 +47,7 @@ checkVC f (fn, vc) = do
   _ <- Utils.executeShellCommand Nothing cmd 100  
   hFlush stdout
   return ()
+-}
 
 esHandle :: Handle -> IO a -> [UserError] -> IO a
 esHandle h exitF es = renderErrors es >>= hPutStrLn h >> exitF

--- a/llvc/app/Main.hs
+++ b/llvc/app/Main.hs
@@ -9,7 +9,7 @@ import System.Exit
 import System.IO                        
 import Language.LLVC.Parse 
 import Language.LLVC.UX 
-import qualified Language.LLVC.Utils as Utils 
+-- import qualified Language.LLVC.Utils as Utils 
 import Language.LLVC.Verify 
 import Language.LLVC.Smt 
 
@@ -31,10 +31,13 @@ filterGoals All       xs = xs
 filterGoals (Some fs) xs = filter ((`elem` fs) . fst) xs 
 
 checkVC :: FilePath -> (Text, VC) -> IO () 
-checkVC f (fn, vc) = 
-  runQuery f smtF vc
-  where 
-    smtF = f <.> tail fn <.> "smt2"
+checkVC f (fn, vc) = do 
+  let smtF = f <.> tail fn <.> "smt2"
+  errSpans <- runQuery smtF vc
+  let errs = mkError "Failed check" <$> errSpans 
+  esHandle stderr exitFailure errs
+
+
 {- 
 checkVC :: FilePath -> (Text, VC) -> IO () 
 checkVC f (fn, vc) = do 

--- a/llvc/app/Main.hs
+++ b/llvc/app/Main.hs
@@ -1,64 +1,50 @@
 module Main where
 
-import Control.Monad (forM_) 
-import Control.Exception
+import qualified Data.List as L
+import           Control.Exception
+import           System.Environment 
+import           System.FilePath 
+import           System.Exit
+import           Language.LLVC.UX 
+import           Language.LLVC.Parse 
+import           Language.LLVC.Verify 
+import           Language.LLVC.Smt 
+import qualified Language.LLVC.Utils as Utils 
+
 -- import System.Process (runCommand) 
-import System.Environment 
-import System.FilePath 
-import System.Exit
-import System.IO                        
-import Language.LLVC.Parse 
-import Language.LLVC.UX 
--- import qualified Language.LLVC.Utils as Utils 
-import Language.LLVC.Verify 
-import Language.LLVC.Smt 
+-- import Control.Monad (forM_) 
+-- import System.IO 
 
 main :: IO ()
-main = exec `catch` esHandle stderr exitFailure
+main = (getGoal >>= llvc)
+          `catch` 
+             esHandle Utils.Crash exitFailure
 
-exec :: IO ()
-exec = getGoal >>= llvc 
+ 
 
 llvc :: FileGoal -> IO () 
 llvc (f, g) = do 
-  p     <- parseFile f 
-  let gs = filterGoals g (vcs p)  
-  forM_ gs (checkVC f)
+  putStrLn $ "\nllvc: checking " ++ show f 
+  p       <- parseFile f 
+  let gs   = filterGoals g (vcs p)  
+  putStrLn $ "\nGoals: " ++ L.intercalate ", " (fst <$> gs) ++ "\n" 
+  errs    <- concat <$> mapM (checkVC f) gs 
+  case errs of 
+    [] -> esHandle Utils.Safe   exitSuccess [] 
+    _  -> esHandle Utils.Unsafe exitFailure errs
 
 filterGoals :: Goal -> [(Text, VC)] -> [(Text, VC)]
 filterGoals None      _   = [] 
 filterGoals All       xs = xs 
 filterGoals (Some fs) xs = filter ((`elem` fs) . fst) xs 
 
-checkVC :: FilePath -> (Text, VC) -> IO () 
+checkVC :: FilePath -> (Text, VC) -> IO [UserError] 
 checkVC f (fn, vc) = do 
   let smtF = f <.> tail fn <.> "smt2"
-  errSpans <- runQuery smtF vc
-  let errs = mkError "Failed check" <$> errSpans 
-  esHandle stderr exitFailure errs
+  runQuery smtF vc
 
-
-{- 
-checkVC :: FilePath -> (Text, VC) -> IO () 
-checkVC f (fn, vc) = do 
-  let smtF = f <.> tail fn <.> "smt2"
-  -- let logF = f <.> "log"
-  let cmd  = "z3 " ++ smtF 
-  -- putStrLn $ "** Generate VC for " ++ fn
-  writeQuery smtF vc 
-  -- putStrLn $ "** Check VC for " ++ fn
-  _ <- Utils.executeShellCommand Nothing cmd 100  
-  hFlush stdout
-  return ()
--}
-
-esHandle :: Handle -> IO a -> [UserError] -> IO a
-esHandle h exitF es = renderErrors es >>= hPutStrLn h >> exitF
-
-verify :: FilePath -> IO ()
-verify f = do 
-  putStrLn ("LLVC: checking " ++ show f) 
-  return ()
+esHandle :: Utils.ExitStatus -> IO a -> [UserError] -> IO a
+esHandle status exitF es = Utils.exitStatus status >> renderErrors es >>= putStrLn >> exitF
 
 ----
 
@@ -69,11 +55,10 @@ getGoal = argsGoal <$> getArgs
 
 argsGoal :: [String] -> FileGoal 
 argsGoal (f:rest) = (f, goal rest) 
-argsGoal _        = error "usage: 'llvc FILE {*, function-name}'" 
+argsGoal _        = error "usage: 'llvc FILE [function-name]'" 
 
 goal :: [String] -> Goal 
-goal []      = None 
-goal ("*":_) = All 
+goal []      = All 
 goal fs      = Some fs 
 
 data Goal 

--- a/llvc/app/Main.hs
+++ b/llvc/app/Main.hs
@@ -22,10 +22,9 @@ main = (getGoal >>= llvc)
 
 llvc :: FileGoal -> IO () 
 llvc (f, g) = do 
-  -- putStrLn $ "\nllvc: checking " ++ show f 
+  putStrLn "" 
   p       <- parseFile f 
   let gs   = filterGoals g (vcs p)  
-  -- putStrLn $ "\nGoals: " ++ L.intercalate ", " (fst <$> gs) ++ "\n" 
   errs    <- concat <$> mapM (checkVC f) gs 
   case errs of 
     [] -> esHandle Utils.Safe   exitSuccess [] 

--- a/llvc/app/Main.hs
+++ b/llvc/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import qualified Data.List as L
+-- import qualified Data.List as L
 import           Control.Exception
 import           System.Environment 
 import           System.FilePath 
@@ -20,26 +20,20 @@ main = (getGoal >>= llvc)
           `catch` 
              esHandle Utils.Crash exitFailure
 
- 
-
 llvc :: FileGoal -> IO () 
 llvc (f, g) = do 
-  putStrLn $ "\nllvc: checking " ++ show f 
+  -- putStrLn $ "\nllvc: checking " ++ show f 
   p       <- parseFile f 
   let gs   = filterGoals g (vcs p)  
-  putStrLn $ "\nGoals: " ++ L.intercalate ", " (fst <$> gs) ++ "\n" 
+  -- putStrLn $ "\nGoals: " ++ L.intercalate ", " (fst <$> gs) ++ "\n" 
   errs    <- concat <$> mapM (checkVC f) gs 
   case errs of 
     [] -> esHandle Utils.Safe   exitSuccess [] 
     _  -> esHandle Utils.Unsafe exitFailure errs
 
-filterGoals :: Goal -> [(Text, VC)] -> [(Text, VC)]
-filterGoals None      _   = [] 
-filterGoals All       xs = xs 
-filterGoals (Some fs) xs = filter ((`elem` fs) . fst) xs 
-
 checkVC :: FilePath -> (Text, VC) -> IO [UserError] 
 checkVC f (fn, vc) = do 
+  putStrLn $ "llvc checking: " ++ fn
   let smtF = f <.> tail fn <.> "smt2"
   runQuery smtF vc
 
@@ -49,6 +43,10 @@ esHandle status exitF es = Utils.exitStatus status >> renderErrors es >>= putStr
 ----
 
 type FileGoal = (FilePath, Goal) 
+
+filterGoals :: Goal -> [(Text, VC)] -> [(Text, VC)]
+filterGoals All       xs = xs
+filterGoals (Some fs) xs = filter ((`elem` fs) . fst) xs 
 
 getGoal :: IO FileGoal 
 getGoal = argsGoal <$> getArgs
@@ -64,5 +62,4 @@ goal fs      = Some fs
 data Goal 
   = Some [Text]   -- ^ Check a single function's VC
   | All           -- ^ Check all  functions' VC
-  | None          -- ^ Don't check, just generate VCs 
   deriving (Eq, Show)

--- a/llvc/include/prelude.smt2
+++ b/llvc/include/prelude.smt2
@@ -6,17 +6,21 @@
 (define-const addmin Float32 ((_ to_fp 8 24) #x0c000000))
 (define-const zero Float32 ((_ to_fp 8 24) #x00000000))
 
+;
+(define-fun plus ((a Int) (b Int)) Int 
+  (+ a b)
+) 
 ; some functions on Int32
-(define-fun lt    ((a Int32) (b Int32)) Bool 
+(define-fun lt32    ((a Int32) (b Int32)) Bool 
   (bvslt a b)
 )
-(define-fun rng   ((n Int32) (x Int32)) Bool 
+(define-fun rng32   ((n Int32) (x Int32)) Bool 
   (or (= #x00000000 x) (bvsle n x))
 )
-(define-fun trunc ((n Int32) (x Int32)) Int32 
+(define-fun trunc32 ((n Int32) (x Int32)) Int32 
   (ite (bvslt x n) #x00000000 x)
 )
-(define-fun plus  ((a Int32) (b Int32)) Int32 
+(define-fun plus32  ((a Int32) (b Int32)) Int32 
   (bvadd a b)
 ) 
 ; some functions on Float32 

--- a/llvc/llvc.cabal
+++ b/llvc/llvc.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6fd52f8c21883d0cec0ab1775ddf93573a5d51bab11b689b419ddc2aa08d3029
+-- hash: e5bfa68c7d9743ec4d8f7e827a21e1b91c858b979a0d27f8286addcb7ed1abc2
 
 name:           llvc
 version:        0.1.0.0
@@ -41,6 +41,7 @@ library
     , hashable
     , megaparsec
     , process
+    , text
     , unordered-containers
   exposed-modules:
       Language.LLVC.Parse
@@ -69,6 +70,7 @@ executable llvc
     , llvc
     , megaparsec
     , process
+    , text
     , unordered-containers
   other-modules:
       Paths_llvc
@@ -90,6 +92,7 @@ test-suite llvc-test
     , llvc
     , megaparsec
     , process
+    , text
     , unordered-containers
   other-modules:
       Paths_llvc

--- a/llvc/llvc.cabal
+++ b/llvc/llvc.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e5bfa68c7d9743ec4d8f7e827a21e1b91c858b979a0d27f8286addcb7ed1abc2
+-- hash: 055afb197c75468d810acd161c0ac838385dd6d1778a689377aad8d17cb94a8a
 
 name:           llvc
 version:        0.1.0.0
@@ -33,7 +33,8 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <5
+      ansi-terminal
+    , base >=4.7 && <5
     , cmdargs
     , containers
     , directory
@@ -61,7 +62,8 @@ executable llvc
       app
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      ansi-terminal
+    , base >=4.7 && <5
     , cmdargs
     , containers
     , directory
@@ -83,7 +85,8 @@ test-suite llvc-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      ansi-terminal
+    , base >=4.7 && <5
     , cmdargs
     , containers
     , directory

--- a/llvc/llvc.cabal
+++ b/llvc/llvc.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 055afb197c75468d810acd161c0ac838385dd6d1778a689377aad8d17cb94a8a
+-- hash: 4413e456c1128433ecbe709910a45c523141949ddb74bbd2e2194efaefc6b5b5
 
 name:           llvc
 version:        0.1.0.0
@@ -34,6 +34,7 @@ library
   ghc-options: -Wall
   build-depends:
       ansi-terminal
+    , attoparsec
     , base >=4.7 && <5
     , cmdargs
     , containers
@@ -63,6 +64,7 @@ executable llvc
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       ansi-terminal
+    , attoparsec
     , base >=4.7 && <5
     , cmdargs
     , containers
@@ -86,6 +88,7 @@ test-suite llvc-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       ansi-terminal
+    , attoparsec
     , base >=4.7 && <5
     , cmdargs
     , containers

--- a/llvc/package.yaml
+++ b/llvc/package.yaml
@@ -22,6 +22,7 @@ description:         Please see the README on Github at <https://github.com/ucsd
 dependencies:
 - base >= 4.7 && < 5
 - cmdargs
+- attoparsec
 - process
 - directory
 - filepath

--- a/llvc/package.yaml
+++ b/llvc/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 - containers
 - unordered-containers
 - megaparsec
+- text
 
 data-files:
 - include/prelude.smt2

--- a/llvc/package.yaml
+++ b/llvc/package.yaml
@@ -30,6 +30,7 @@ dependencies:
 - unordered-containers
 - megaparsec
 - text
+- ansi-terminal
 
 data-files:
 - include/prelude.smt2

--- a/llvc/src/Language/LLVC/Parse.hs
+++ b/llvc/src/Language/LLVC/Parse.hs
@@ -90,10 +90,17 @@ argTypeP = do
   return (x, t)
 
 bodyP :: Parser BareBody
-bodyP = FnBody <$> many assignP <*> retP 
+bodyP = FnBody <$> many stmtP <*> retP 
 
-assignP :: Parser (BareVar, BareExpr) 
-assignP = (,) <$> identifier "%" <* symbol "=" <*> exprP
+stmtP :: Parser BareStmt 
+stmtP 
+  =  flip SAssert <$> (symbol ";@" *> rWord "assert") <*> predP
+ <|> mkAsgn       <$> (identifier "%" <* symbol "=")  <*> exprP
+  where 
+    mkAsgn (x,l) e = SAsgn x e l 
+
+-- assignP :: Parser (BareVar, BareExpr) 
+-- assignP = (,) <$> identifier "%" <* symbol "=" <*> exprP
 
 argTypesP :: Parser [(Var, Type)] 
 argTypesP = parens (sepBy argTypeP comma) 

--- a/llvc/src/Language/LLVC/Parse.hs
+++ b/llvc/src/Language/LLVC/Parse.hs
@@ -220,7 +220,7 @@ pAtomP
  <|> atomOp 
  
 atomOp :: Parser Pred 
-atomOp = PAtom <$> (SmtOp <$> varP "") <*> many pArgP 
+atomOp = PAtom <$> (SmtOp . fst <$> smtId) <*> many pArgP 
 
 atom1 :: Text -> Op -> Parser Pred 
 atom1 kw o = (\x1 -> PAtom o [x1]) 

--- a/llvc/src/Language/LLVC/Smt.hs
+++ b/llvc/src/Language/LLVC/Smt.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE BangPatterns         #-}
 
 module Language.LLVC.Smt 
   ( -- * Opaque SMT Query type 
@@ -16,8 +17,18 @@ module Language.LLVC.Smt
 
     -- * Issuing Query
   , writeQuery 
+  
+    -- * Executing Query 
+  , runQuery 
   ) 
   where 
+
+import qualified Data.Text                as T
+import qualified Data.Text.Lazy.Builder   as LT
+-- import           Text.PrettyPrint.HughesPJ
+    
+import           System.IO                (Handle)
+import           System.Process
 
 import           Text.Printf (printf) 
 import           Data.Monoid
@@ -31,7 +42,6 @@ writeQuery :: FilePath -> VC -> IO ()
 writeQuery f vc = do 
   prelude  <- readPrelude 
   writeFile f $ prelude ++ toSmt vc 
--- (preamble <> vc))
 
 readPrelude :: IO UX.Text 
 readPrelude = readFile =<< Paths_llvc.getDataFileName "include/prelude.smt2"
@@ -44,7 +54,11 @@ class ToSmt a where
   toSmt :: a -> Smt 
 
 instance ToSmt VC where 
-  toSmt (VC cmds) = unlines [ c | Cmd c <- cmds] 
+  toSmt (VC cmds) = unlines (toSmt <$> cmds) 
+
+instance ToSmt Cmd where 
+  toSmt (Say s)    = s 
+  toSmt (Hear s _) = s 
 
 instance ToSmt Op where 
   toSmt BvAnd     = "bvand"
@@ -117,57 +131,130 @@ sanitizeChar c   = c
 -------------------------------------------------------------------------------
 
 type    Smt = UX.Text
-newtype Cmd = Cmd UX.Text
 newtype VC  = VC [Cmd] 
+data Cmd    = Say  !Smt 
+            | Hear !Smt !UX.SourceSpan
 
 instance Monoid VC where 
   mempty                  = VC [] 
   mappend (VC q1) (VC q2) = VC (q1 <> q2) 
 
 -------------------------------------------------------------------------------
--- | Basic Commands 
+-- | VC Construction API 
 -------------------------------------------------------------------------------
 
 comment :: UX.Text -> VC 
-comment s = cmd $ printf "; %s" s
+comment s = say $ printf "; %s" s
 
-declare :: (Var, Type) -> VC 
-declare (x, t) = cmd $ printf "(declare-const %s %s)" (toSmt x) (toSmt t)
+declare :: (UX.Located l) => l -> (Var, Type) -> VC 
+declare _ (x, t) = say $ printf "(declare-const %s %s)" (toSmt x) (toSmt t)
 
-assert :: Pred -> VC 
-assert PTrue = mempty 
-assert p     = cmd $ printf "(assert %s)" (toSmt p)
+assert :: (UX.Located l) => l -> Pred -> VC 
+assert _ PTrue = mempty 
+assert _ p     = say $ printf "(assert %s)" (toSmt p)
 
-check :: Pred -> VC 
-check PTrue = mempty 
-check p     = withBracket (assert (PNot p) <> checkSat) 
+check :: (UX.Located l) => l -> Pred -> VC 
+check _ PTrue = mempty 
+check l p     = withBracket (assert l (PNot p) <> checkSat sp)
+  where 
+    sp        = UX.sourceSpan l
 
 withBracket :: VC -> VC 
 withBracket vc = push <> vc <> pop 
 
-push, pop, checkSat :: VC 
-push     = cmd "(push 1)"
-pop      = cmd "(pop 1)"
-checkSat = cmd "(check-sat)" 
+push, pop :: VC 
+push     = say  "(push 1)"
+pop      = say  "(pop 1)"
 
-_preamble :: VC 
-_preamble = mconcat $ cmd <$> 
-  [ "(set-logic QF_FPBV)"
-  , "(define-sort Int1    () Bool)"
-  , "(define-sort Int32   () (_ BitVec 32))"
-  -- , "(define-sort Float32 () (_ FloatingPoint  8 24))"
-  , "(define-fun to_fp_32 ((a Int32)) Float32  ((_ to_fp 8 24) RNE a))"
-  , "(define-fun fp_add ((a Float32) (b Float32)) Float32 (fp.add RNE a b))"
-  , "(define-const addmin Float32 ((_ to_fp 8 24) #x0c000000))"  
-  , "(define-const zero Float32 ((_ to_fp 8 24) #x00000000))"
+checkSat :: UX.SourceSpan -> VC
+checkSat l = VC [ Hear "(check-sat)" l ]
 
-  , "(define-fun lt ((a Int32) (b Int32)) Bool (bvslt a b))" 
-  , "(define-fun rng ((n Int32) (x Int32)) Bool (or (= 0 x) (<= n x)))" 
-  , "(define-fun trunc ((n Int32) (x Int32)) Int32 (ite (< x n) 0 x))"
-  , "(define-fun copysign ((a Float32) (b Float32)) Float32\ 
-     \  (to_fp_32 (bvor (bvand (to_ieee_bv a) #x7fffffff)\ 
-     \                  (bvand (to_ieee_bv b) #x80000000))))"
-  ]
+say :: UX.Text -> VC
+say s = VC [ Say s ]
 
-cmd :: UX.Text -> VC
-cmd s = VC [ Cmd s ]
+-------------------------------------------------------------------------------
+-- | VC "Execution" API 
+-------------------------------------------------------------------------------
+
+runQuery :: VC -> IO [UX.SourceSpan]
+runQuery = error "TODO:runQuery"
+
+makeContext   :: Config -> FilePath -> IO Context
+makeContext cfg f
+  = do me       <- makeProcess cfg
+       prelude  <- readPrelude 
+       createDirectoryIfMissing True $ takeDirectory smtFile
+       hLog     <- openFile smtFile WriteMode
+       let me'   = me { ctxLog = Just hLog }
+       mapM_ (smtWrite me') prelude
+       return me'
+    where
+       smtFile = f <.> "smt2" 
+
+smtWrite :: Context -> Raw -> IO ()
+smtWrite me !s = smtWriteRaw me s
+
+smtRead :: Context -> IO Response
+smtRead me = {-# SCC "smtRead" #-} do
+  when (ctxVerbose me) $ LTIO.putStrLn "SMT READ"
+  ln  <- smtReadRaw me
+  res <- A.parseWith (smtReadRaw me) responseP ln
+  case A.eitherResult res of
+    Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
+    Right r -> do
+      maybe (return ()) (\h -> hPutStrLnNow h $ format "; SMT Says: {}" (Only $ show r)) (ctxLog me)
+      when (ctxVerbose me) $ LTIO.putStrLn $ format "SMT Says: {}" (Only $ show r)
+      return r
+
+smtWriteRaw      :: Context -> Raw -> IO ()
+smtWriteRaw me !s = {-# SCC "smtWriteRaw" #-} do
+  hPutStrLnNow (ctxCout me) s
+  maybe (return ()) (`hPutStrLnNow` s) (ctxLog me)
+
+smtReadRaw       :: Context -> IO T.Text
+smtReadRaw me    = {-# SCC "smtReadRaw" #-} TIO.hGetLine (ctxCin me)
+
+hPutStrLnNow     :: Handle -> LT.Text -> IO ()
+hPutStrLnNow h !s = LTIO.hPutStrLn h s >> hFlush h
+
+type SmtParser a = Parser T.Text a
+
+responseP :: SmtParser Response
+responseP = {-# SCC "responseP" #-} A.char '(' *> sexpP
+         <|> A.string "sat"     *> return Sat
+         <|> A.string "unsat"   *> return Unsat
+         <|> A.string "unknown" *> return Unknown
+
+--------------------------------------------------------------------------------
+command              :: Context -> Cmd -> IO Response
+--------------------------------------------------------------------------------
+command me !cmd       = say cmd >> hear cmd
+  where
+    env               = ctxSymEnv me
+    say               = smtWrite me . Builder.toLazyText . runSmt2 env
+    hear CheckSat     = smtRead me
+    hear (GetValue _) = smtRead me
+    hear _            = return Ok
+
+makeProcess :: IO Context
+makeProcess = do 
+  (hOut, hIn, _ ,pid) <- runInteractiveCommand "z3" 
+  loud <- isLoud
+  return Ctx { ctxPid     = pid
+             , ctxCin     = hIn
+             , ctxCout    = hOut
+             , ctxLog     = Nothing
+             , ctxVerbose = loud
+             }
+
+data Response 
+  = Ok 
+  | Fail !UX.SourceSpan 
+
+data Context = Ctx
+  { ctxPid     :: !ProcessHandle
+  , ctxCin     :: !Handle
+  , ctxCout    :: !Handle
+  , ctxLog     :: !(Maybe Handle)
+  , ctxVerbose :: !Bool
+  }

--- a/llvc/src/Language/LLVC/Smt.hs
+++ b/llvc/src/Language/LLVC/Smt.hs
@@ -54,7 +54,6 @@ instance ToSmt Op where
   toSmt FpEq      = "fp.eq" 
   toSmt FpAbs     = "fp.abs" 
   toSmt FpLt      = "fp.lt" 
-  -- toSmt ToFp32 = "to_fp_32" 
   toSmt ToFp32    = "(_ to_fp 8 24) RNE"
   toSmt Ite       = "ite" 
   toSmt Eq        = "=" 

--- a/llvc/src/Language/LLVC/Smt.hs
+++ b/llvc/src/Language/LLVC/Smt.hs
@@ -215,7 +215,7 @@ data Context = Ctx
 --------------------------------------------------------------------------------
 makeContext :: FilePath -> IO Context
 --------------------------------------------------------------------------------
-makeContext f = do 
+makeContext smtFile = do 
   me       <- makeProcess 
   prelude  <- readPrelude 
   createDirectoryIfMissing True $ takeDirectory smtFile
@@ -223,8 +223,6 @@ makeContext f = do
   let me'   = me { ctxLog = Just hLog }
   smtWrite me' (T.pack prelude)
   return me'
-  where
-    smtFile = f <.> "smt2" 
 
 makeProcess :: IO Context
 makeProcess = do 

--- a/llvc/src/Language/LLVC/Types.hs
+++ b/llvc/src/Language/LLVC/Types.hs
@@ -186,6 +186,9 @@ instance Labeled Arg where
 instance Labeled Expr where 
   getLabel (ECall _ _ _ z) = z 
   
+instance Labeled FnDef where 
+  getLabel = fnLab 
+
 -------------------------------------------------------------------------------
 -- | Constructors 
 -------------------------------------------------------------------------------

--- a/llvc/src/Language/LLVC/UX.hs
+++ b/llvc/src/Language/LLVC/UX.hs
@@ -33,6 +33,7 @@ module Language.LLVC.UX
   , PPrint (..)
   ) where
 
+import           Data.Function (on) 
 import           Control.Exception
 import           Data.Typeable
 import qualified Data.List as L
@@ -64,7 +65,7 @@ data SourceSpan = SS
   { ssBegin :: !SourcePos
   , ssEnd   :: !SourcePos
   }
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 instance Monoid SourceSpan where
   mempty  = junkSpan
@@ -201,8 +202,8 @@ mkError = Error
 
 renderErrors :: [UserError] -> IO Text
 renderErrors es = do
-  errs  <- mapM renderError es
-  return $ L.intercalate "\n" ("Errors found!" : errs)
+  errs  <- mapM renderError (L.sortBy (compare `on` eSpan) es)
+  return $ L.intercalate "\n" (" " : errs)
 
 renderError :: UserError -> IO Text
 renderError e = do

--- a/llvc/src/Language/LLVC/Utils.hs
+++ b/llvc/src/Language/LLVC/Utils.hs
@@ -17,6 +17,7 @@ import           System.IO
 import           System.Process
 import           System.Timeout
 import           System.Console.CmdArgs.Verbosity (whenLoud)
+import           System.Console.ANSI
 import           Debug.Trace (trace)
 
 --------------------------------------------------------------------------------
@@ -31,8 +32,6 @@ f >-> g = f >=> safe g
 mconcatMap :: (Monoid b) => (a -> b) -> [a] -> b 
 --------------------------------------------------------------------------------
 mconcatMap f = mconcat . fmap f
-
-
 
 groupBy :: (Ord k) => (a -> k) -> [a] -> [(k, [a])]
 groupBy f = M.toList . L.foldl' (\m x -> inserts (f x) x m) M.empty
@@ -98,3 +97,19 @@ integerBinary i = showIntAtBase 2 intToDigit i ""
 
 -- putStrLn $ showHex 12 "" -- prints "c"
 -- putStrLn $ showIntAtBase 2 intToDigit 12 "" -- prints "1100"
+
+withColor :: Color -> IO () -> IO ()
+withColor c act = do 
+  setSGR [ SetConsoleIntensity BoldIntensity, SetColor Foreground Vivid c]
+  act
+  setSGR [ Reset]
+
+data ExitStatus 
+  = Safe 
+  | Unsafe 
+  | Crash 
+
+exitStatus :: ExitStatus -> IO () 
+exitStatus Safe   = withColor Green  $ putStrLn "Yay! Safe!"
+exitStatus Unsafe = withColor Red    $ putStrLn "Yikes, errors found!"
+exitStatus Crash  = withColor Yellow $ putStrLn "Oops, crash!"

--- a/llvc/src/Language/LLVC/Utils.hs
+++ b/llvc/src/Language/LLVC/Utils.hs
@@ -110,6 +110,6 @@ data ExitStatus
   | Crash 
 
 exitStatus :: ExitStatus -> IO () 
-exitStatus Safe   = withColor Green  $ putStrLn "Yay! Safe!"
-exitStatus Unsafe = withColor Red    $ putStrLn "Yikes, errors found!"
-exitStatus Crash  = withColor Yellow $ putStrLn "Oops, crash!"
+exitStatus Safe   = withColor Green  $ putStrLn "\nYay! Safe!"
+exitStatus Unsafe = withColor Red    $ putStrLn "\nYikes, errors found!"
+exitStatus Crash  = withColor Yellow $ putStrLn "\nOops, crash!"

--- a/llvc/src/Language/LLVC/Verify.hs
+++ b/llvc/src/Language/LLVC/Verify.hs
@@ -28,13 +28,14 @@ vcFun env fd fb = comment    ("VC for: " ++  fnName fd)
                <> mconcatMap (declare l)  (fnArgTys fd) 
                <> assert     l             pre
                <> mconcatMap (vcStmt env) (fnStmts  fb)
-               <> check      l (subst su    post) 
+               <> check      l' (subst su    post) 
   where 
-    su          = [(retVar, snd (fnRet fb))]
+    su          = [(retVar, retExp)]
+    retExp      = snd (fnRet fb)
     pre         = ctPre  (fnCon fd)        
     post        = ctPost (fnCon fd)
     l           = sourceSpan (getLabel fd)
-
+    l'          = sourceSpan (getLabel retExp)
 
 vcStmt :: (Located a) => Env -> Stmt a -> VC 
 vcStmt _ (SAssert p l) 

--- a/llvc/src/Language/LLVC/Verify.hs
+++ b/llvc/src/Language/LLVC/Verify.hs
@@ -25,24 +25,25 @@ vcs p   = [ (f, vcFun env fd fb)
 
 vcFun :: (Located a) => Env -> FnDef a -> FnBody a -> VC 
 vcFun env fd fb = comment    ("VC for: " ++  fnName fd)
-               <> mconcatMap declare      (fnArgTys fd) 
-               <> assert                  pre
+               <> mconcatMap (declare l)  (fnArgTys fd) 
+               <> assert     l             pre
                <> mconcatMap (vcStmt env) (fnStmts  fb)
-               <> check      (subst su    post) 
+               <> check      l (subst su    post) 
   where 
     su          = [(retVar, snd (fnRet fb))]
     pre         = ctPre  (fnCon fd)        
     post        = ctPost (fnCon fd)
+    l           = sourceSpan (getLabel fd)
 
 
 vcStmt :: (Located a) => Env -> Stmt a -> VC 
-vcStmt _ (SAssert p _) 
-  = check p
+vcStmt _ (SAssert p l) 
+  = check l p 
 vcStmt env asgn@(SAsgn x (ECall fn tys tx l) _)
   =  comment (pprint asgn)
-  <> declare (x, tx) 
-  <> check  pre 
-  <> assert post 
+  <> declare l (x, tx) 
+  <> check  l pre
+  <> assert l post 
   where 
     (pre, post) = contractAt env fn x tys l 
 

--- a/llvc/src/Language/LLVC/Verify.hs
+++ b/llvc/src/Language/LLVC/Verify.hs
@@ -62,14 +62,6 @@ contractAt env fn rv tys l = (pre, post)
     formals                = retVar    : ctParams ct
     ct                     = contract env fn (sourceSpan l) 
 
--- resultType :: Program a -> Fn -> [TypedArg a] -> Type -> Type 
--- resultType _ _ _ t           = t 
--- resultType _ (FnFunc _) _ t  = t 
--- resultType _ (FnBin _) _  t  = t 
--- resultType _ (FnFcmp _) _ t  = t 
--- resultType _ FnSelect _ t    = t 
--- resultType _ FnBitcast _ t   = t 
-
 -------------------------------------------------------------------------------
 -- | Contracts for all the `Fn` stuff.
 -------------------------------------------------------------------------------
@@ -119,8 +111,6 @@ primitiveContracts =
   , ( FnBitcast Float (I 32) 
     , postCond 1 "(= %ret (to_ieee_bv  %arg0))" )
 
---  , ( FnFunc "@llvm.fabs.f32"
---    , postCond 1 "(fp.eq %ret (fp.abs %arg0))" )
   ] 
 
 postCond :: Int -> Text -> Contract 
@@ -132,7 +122,6 @@ mkContract n tPre tPost = Ct
   , ctPre    = pred tPre 
   , ctPost   = pred tPost 
   } 
-
 
 pred :: Text -> Pred 
 pred = Parse.parseWith Parse.predP "primitive-contracts" 

--- a/llvc/src/Language/LLVC/Verify.hs
+++ b/llvc/src/Language/LLVC/Verify.hs
@@ -27,19 +27,22 @@ vcFun :: (Located a) => Env -> FnDef a -> FnBody a -> VC
 vcFun env fd fb = comment    ("VC for: " ++  fnName fd)
                <> mconcatMap declare      (fnArgTys fd) 
                <> assert                  pre
-               <> mconcatMap (vcAsgn env) (fnAsgns  fb)
+               <> mconcatMap (vcStmt env) (fnStmts  fb)
                <> check      (subst su    post) 
   where 
     su          = [(retVar, snd (fnRet fb))]
     pre         = ctPre  (fnCon fd)        
     post        = ctPost (fnCon fd)
 
-vcAsgn :: (Located a) => Env  -> ((Var, a), Expr a) -> VC 
-vcAsgn env asgn@((x, _), ECall fn tys tx l) 
-                = comment (ppAsgn asgn)
-               <> declare (x, tx) 
-               <> check  pre 
-               <> assert post 
+
+vcStmt :: (Located a) => Env -> Stmt a -> VC 
+vcStmt _ (SAssert p _) 
+  = check p
+vcStmt env asgn@(SAsgn x (ECall fn tys tx l) _)
+  =  comment (pprint asgn)
+  <> declare (x, tx) 
+  <> check  pre 
+  <> assert post 
   where 
     (pre, post) = contractAt env fn x tys l 
 
@@ -124,7 +127,6 @@ mkContract n tPre tPost = Ct
   , ctPost   = pred tPost 
   } 
 
--- Ct (paramVar <$> [0..(n-1)]) PTrue . pred 
 
 pred :: Text -> Pred 
 pred = Parse.parseWith Parse.predP "primitive-contracts" 

--- a/llvc/test/ll/restrict.cse.ll
+++ b/llvc/test/ll/restrict.cse.ll
@@ -14,6 +14,7 @@ define weak float @ctfp_restrict_add_f32v1(float %a, float %b) #1 {
 ;@ ensures  (= %ret (fp_add (fp_trunc addmin %a) (fp_trunc addmin %b)))
   %1 = call float @llvm.fabs.f32(float %a)
   %2 = fcmp olt float %1, 0x3980000000000000
+  ;@ assert (= 5 (+ 2 3))
   %3 = select i1 %2, i32 -1, i32 0
   %4 = bitcast i32 %3 to float
   %5 = xor i32 %3, -1

--- a/llvc/test/ll/restrict.cse.ll
+++ b/llvc/test/ll/restrict.cse.ll
@@ -14,7 +14,7 @@ define weak float @ctfp_restrict_add_f32v1(float %a, float %b) #1 {
 ;@ ensures  (= %ret (fp_add (fp_trunc addmin %a) (fp_trunc addmin %b)))
   %1 = call float @llvm.fabs.f32(float %a)
   %2 = fcmp olt float %1, 0x3980000000000000
-  ;@ assert (= 5 (+ 2 3))
+  ;@ assert (= 5 (plus 2 3))
   %3 = select i1 %2, i32 -1, i32 0
   %4 = bitcast i32 %3 to float
   %5 = xor i32 %3, -1


### PR DESCRIPTION
@marcandrysco I think I'm done with this first cut.

See the README for how to run. 

It now prints out the location/type of failed check e.g. 

- failed precondition at call-site, or
- failed post-condition at return, or 
- a failed assertion.

Additionally, in each case, `llvc` prints out the model produced by z3.

Btw, @deian  I kept the plain `smt2` interface on the off chance that Andres' 
suggests that we switch to `cvc4` or `boolector` or some other solver that 
is better at bit-vectors and floating point?

@marcandrysco -- the first priority is for you to figure out contracts that 
make `llvc test/ll/restrict.cse.ll` say `Safe`. 
